### PR TITLE
fix: syntax correction and removing redundant logs

### DIFF
--- a/django_app/redbox_app/settings.py
+++ b/django_app/redbox_app/settings.py
@@ -178,7 +178,7 @@ CSP_FONT_SRC = (
 )
 CSP_STYLE_SRC = ("'self'",)
 CSP_FRAME_ANCESTORS = ("'none'",)
-CSP_FRAME_SRC = ("'self'", env.str("STREAMLIT_HOST"))
+CSP_FRAME_SRC = ("'self'", f"http://{env.str('STREAMLIT_HOST')}")
 CSP_CONNECT_SRC = ["'self'", f"wss://{env_hosts[0]}/ws/chat/", "plausible.io"]
 
 # https://pypi.org/project/django-permissions-policy/

--- a/notebooks/evaluation/Dockerfile
+++ b/notebooks/evaluation/Dockerfile
@@ -1,6 +1,6 @@
 FROM python:3.11-buster as builder
 
-WORKDIR /app/
+WORKDIR /app
 
 RUN pip install poetry
 
@@ -26,7 +26,7 @@ COPY notebooks/evaluation/app.py /app/
 
 FROM python:3.11-slim as runtime
 
-WORKDIR /app/
+WORKDIR /app
 
 RUN apt-get update && apt-get install --yes libpq-dev curl > /dev/null
 
@@ -41,4 +41,4 @@ COPY --from=builder /app/django_app /app/django_app
 
 EXPOSE 8501
 
-CMD ["streamlit", "run", "notebooks/evaluation/app.py", "--server.port=8501", "--server.address=0.0.0.0"]
+ENTRYPOINT ["streamlit", "run", "notebooks/evaluation/app.py", "--server.port=8501", "--server.address=0.0.0.0"]

--- a/notebooks/evaluation/analysis_of_chat_history.py
+++ b/notebooks/evaluation/analysis_of_chat_history.py
@@ -41,11 +41,6 @@ class ChatHistoryAnalysis:
         os.makedirs(self.table_dir, exist_ok=True)
 
         self.chat_logs = self.fetch_chat_history()
-        import logging
-        logging.basicConfig(level=logging.INFO)
-        logger = logging.getLogger()
-        logger.info('hello123456')
-        logger.info(self.chat_logs.columns.values)
 
         # Select specific columns and converting to readable timestamp
         self.chat_logs = self.chat_logs[['created_at', 'users_id', 'user_email', 'chat_history', 'text', 'role', 'message_id']]


### PR DESCRIPTION
## Context

<!-- Why are you making this change? What might surprise someone about it? -->
Dockerfile has some syntax errors which cause app.py to not automatically build and there is some redundant logging that I shouldn't have committed into dev.

## Changes proposed in this pull request

<!-- If there are UI changes, please include Before and After screenshots. -->
Removing logging from analysis_of_chat_history.py, using correct paths for Dockerfile and calling correct command to launch

## Guidance to review

<!-- How could someone else check this work? Which parts do you want more feedback on? -->

## Relevant links


## Things to check

- [ ] I have added any new ENV vars in all deployed environments
- [ ] I have tested any code added or changed
- [ ] I have run integration tests
