### PR TITLE
Feat/GitHub actions track upstream

### DIFF
--- a/.github/workflows/pull-upstream-release.yml
+++ b/.github/workflows/pull-upstream-release.yml
@@ -30,7 +30,7 @@ jobs:
       - name: Create new branch if new release found
         if: github.event_name == 'push'
         run: |
-          branch_name = upstream/release-${{ env.latest_tag }}
+          branch_name=upstream/release-${{ env.latest_tag }}
           echo branch_name: $branch_name
           git checkout -b $branch_name
           git push origin $branch_name

--- a/.github/workflows/pull-upstream-release.yml
+++ b/.github/workflows/pull-upstream-release.yml
@@ -28,7 +28,7 @@ jobs:
           echo "latest_tag=$latest_tag" >> $GITHUB_ENV
 
       - name: Create new branch if new release found
-        if: github.event_name == 'push'
+        if: github.event_name == 'schedule'
         run: |
           branch_name=upstream/release-${{ env.latest_tag }}
           echo branch_name: $branch_name
@@ -36,13 +36,3 @@ jobs:
           git push origin $branch_name
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-      
-      - name: Tag the new branch
-        run: |
-          git tag upstream/${{ env.latest_tag }} $branch_name
-          git push origin ${{ env.latest_tag }}
-        env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-
-
-    

--- a/.github/workflows/pull-upstream-release.yml
+++ b/.github/workflows/pull-upstream-release.yml
@@ -30,7 +30,8 @@ jobs:
       - name: Create new branch if new release found
         if: github.event_name == 'push'
         run: |
-          echo "branch_name = "upstream/release-${{ env.latest_tag }}""
+          branch_name = upstream/release-${{ env.latest_tag }}
+          echo branch_name: $branch_name
           git checkout -b $branch_name
           git push origin $branch_name
         env:

--- a/.github/workflows/pull-upstream-release.yml
+++ b/.github/workflows/pull-upstream-release.yml
@@ -13,7 +13,7 @@ jobs:
         uses: actions/checkout@v2
       
       - name: Fetch upstream release_version
-        uses: |
+        run: |
           git remote add upstream https://github.com/i-dot-ai/redbox.git 
           git fetch upstream --tags
         env:

--- a/.github/workflows/pull-upstream-release.yml
+++ b/.github/workflows/pull-upstream-release.yml
@@ -4,6 +4,7 @@ on:
   schedule:
     - cron: '0 8 * * *' # run every day at 8am
   workflow_dispatch:
+  push:
 
 jobs:
   check-upstream-release:

--- a/.github/workflows/pull-upstream-release.yml
+++ b/.github/workflows/pull-upstream-release.yml
@@ -24,7 +24,7 @@ jobs:
         id: check_tag
         run: |
           latest_tag=$(git describe --tags `git rev-list --tags --max-count=1`)
-          echo "Latest tag: "upstream/release-$latest_tag"
+          echo "Latest tag: $latest_tag"
           echo "latest_tag=$latest_tag" >> $GITHUB_ENV
 
       - name: Create new branch if new release found

--- a/.github/workflows/pull-upstream-release.yml
+++ b/.github/workflows/pull-upstream-release.yml
@@ -4,7 +4,6 @@ on:
   schedule:
     - cron: '0 8 * * *' # run every day at 8am
   workflow_dispatch:
-  push:
 
 jobs:
   check-upstream-release:

--- a/.github/workflows/pull-upstream-release.yml
+++ b/.github/workflows/pull-upstream-release.yml
@@ -1,0 +1,39 @@
+name: Detect upstream release
+
+on:
+  schedule:
+    - cron: '0 8 * * *' # run every day at 8am
+  workflow_dispatch:
+
+jobs:
+  check-upstream-release:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v2
+      
+      - name: Fetch upstream release_version
+        uses: |
+          git remote add upstream https://github.com/i-dot-ai/redbox.git 
+          git fetch upstream --tags
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+      
+      - name: Check for new release tag
+        id: check_tag
+        run: |
+          latest_tag=$(git describe --tags `git rev-list --tags --max-count=1`)
+          echo "Latest tag: "upstream/release-$latest_tag"
+          echo "::set-output name=latest_tag::$latest_tag"
+
+      - name: Create new branch if new release found
+        if: github.event_name == 'schedule'
+        run: |
+          branch_name = "upstream/release-$latest_tag"
+          git checkout -b $branch_name upstream/release-$latest_tag
+          git push origin $branch_name
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+
+
+    

--- a/.github/workflows/pull-upstream-release.yml
+++ b/.github/workflows/pull-upstream-release.yml
@@ -30,7 +30,7 @@ jobs:
       - name: Create new branch if new release found
         if: github.event_name == 'push'
         run: |
-          branch_name = "upstream/release-${{ env.latest_tag }}"
+          echo "branch_name = "upstream/release-${{ env.latest_tag }}""
           git checkout -b $branch_name
           git push origin $branch_name
         env:
@@ -38,7 +38,7 @@ jobs:
       
       - name: Tag the new branch
         run: |
-          git tag ${{ env.latest_tag }} $branch_name
+          git tag upstream/${{ env.latest_tag }} $branch_name
           git push origin ${{ env.latest_tag }}
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/pull-upstream-release.yml
+++ b/.github/workflows/pull-upstream-release.yml
@@ -28,11 +28,18 @@ jobs:
           echo "latest_tag=$latest_tag" >> $GITHUB_ENV
 
       - name: Create new branch if new release found
-        if: github.event_name == 'schedule'
+        if: github.event_name == 'push'
         run: |
           branch_name = "upstream/release-${{ env.latest_tag }}"
           git checkout -b $branch_name
           git push origin $branch_name
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+      
+      - name: Tag the new branch
+        run: |
+          git tag ${{ env.latest_tag }} $branch_name
+          git push origin ${{ env.latest_tag }}
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 

--- a/.github/workflows/pull-upstream-release.yml
+++ b/.github/workflows/pull-upstream-release.yml
@@ -25,13 +25,13 @@ jobs:
         run: |
           latest_tag=$(git describe --tags `git rev-list --tags --max-count=1`)
           echo "Latest tag: "upstream/release-$latest_tag"
-          echo "::set-output name=latest_tag::$latest_tag"
+          echo "latest_tag=$latest_tag" >> $GITHUB_ENV
 
       - name: Create new branch if new release found
         if: github.event_name == 'schedule'
         run: |
-          branch_name = "upstream/release-$latest_tag"
-          git checkout -b $branch_name upstream/release-$latest_tag
+          branch_name = "upstream/release-${{ env.latest_tag }}"
+          git checkout -b $branch_name
           git push origin $branch_name
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
## Context

Adding a new Github Actions workflow to automatically detect a new Redbox release and creating a branch on the uktrade/redbox-copilot fork.  This is done by identifying new tags.  The branch name currently follows the format upstream/release-X.X.X.  

This workflow is set to run daily at 8am.  It can also be manually triggered (once merged to main).

## Changes proposed in this pull request

<!-- If there are UI changes, please include Before and After screenshots. -->

## Guidance to review

<!-- How could someone else check this work? Which parts do you want more feedback on? -->

## Relevant links


## Things to check

- [ ] I have added any new ENV vars in all deployed environments
- [ ] I have tested any code added or changed
- [ ] I have run integration tests
