### PR TITLE
change var to expect 'production'

### DIFF
--- a/django_app/redbox_app/templates/base.html
+++ b/django_app/redbox_app/templates/base.html
@@ -27,7 +27,7 @@
     data-domain="redbox.ai.cabinetoffice.gov.uk" src="https://plausible.io/js/script.pageview-props.tagged-events.outbound-links.file-downloads.js"></script>
   {% endif %}
 
-  {% if environment | lower == "prod" and repo_owner | lower == "uktrade" %}
+  {% if environment | lower == "production" and repo_owner | lower == "uktrade" %}
         <!-- Google tag (gtag.js) -->
     <script async src="{{ analytics_link }}"></script>
     <script> 


### PR DESCRIPTION
## Context

Merging straight to main due to issues with dev branch pulling in previously committed & merged changes.

Infra references 'production', django-app GA4 analytics was triggered by environment being set to 'prod', consistent with CO.  Updated to make environment variable to look for 'production'.

## Changes proposed in this pull request

<!-- If there are UI changes, please include Before and After screenshots. -->

## Guidance to review

<!-- How could someone else check this work? Which parts do you want more feedback on? -->

## Relevant links


## Things to check

- [ ] I have added any new ENV vars in all deployed environments
- [ ] I have tested any code added or changed
- [ ] I have run integration tests
