### PR TITLE
Adding load_dotenv()

### DIFF
--- a/django_app/redbox_app/redbox_core/context_processors.py
+++ b/django_app/redbox_app/redbox_core/context_processors.py
@@ -1,6 +1,8 @@
 from django.conf import settings
+from dotenv import load_dotenv
 import environ
 
+load_dotenv()
 env = environ.Env()
 
 def analytics_tag(request):


### PR DESCRIPTION
## Context

Environment variables not loading for context processors..

## Changes proposed in this pull request

<!-- If there are UI changes, please include Before and After screenshots. -->

## Guidance to review

<!-- How could someone else check this work? Which parts do you want more feedback on? -->

## Relevant links


## Things to check

- [ ] I have added any new ENV vars in all deployed environments
- [ ] I have tested any code added or changed
- [ ] I have run integration tests
