### PR TITLE
Feat/user management functions

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -124,7 +124,7 @@ docs-build:  ## Build documentation
 	poetry run mkdocs build
 
 # Docker
-AWS_ACCOUNT_ID=381491837320
+AWS_ACCOUNT_ID=REPLACE_ME
 
 AWS_REGION=eu-west-2
 APP_NAME=dbt

--- a/Makefile
+++ b/Makefile
@@ -124,7 +124,7 @@ docs-build:  ## Build documentation
 	poetry run mkdocs build
 
 # Docker
-AWS_ACCOUNT_ID=REPLACE_ME
+AWS_ACCOUNT_ID=381491837320
 
 AWS_REGION=eu-west-2
 APP_NAME=dbt

--- a/django_app/redbox_app/redbox_core/models.py
+++ b/django_app/redbox_app/redbox_core/models.py
@@ -69,7 +69,7 @@ class SSOUserManager(BaseSSOUserManager):
         extra_fields.setdefault("is_superuser", False)
         return self._create_user(username, password, **extra_fields)
 
-    def create_superuser(self, username, password, **extra_fields):
+    def create_superuser(self, username, password=None, **extra_fields):
         """Create and save a SuperUser with the given email and password."""
         extra_fields.setdefault("is_staff", True)
         extra_fields.setdefault("is_superuser", True)


### PR DESCRIPTION
## Context

`createsuperuser` has not been working since updating the user model to work with SSO.  Updated fix should remove the request for 'raw_password' that is seen when trying to use this function.


## Things to check

- [ ] I have added any new ENV vars in all deployed environments
- [ ] I have tested any code added or changed
- [ ] I have run integration tests
- [ ] I have added/updated any DBT specific changes to .env.uktrade
