### PR TITLE
fix: summarise route not working

### DIFF
--- a/core-api/core_api/routes/chat.py
+++ b/core-api/core_api/routes/chat.py
@@ -48,7 +48,7 @@ async def route_chat(
 
     def select_chat_chain(chat_request: ChatRequest, routable_chains: dict[str, Runnable]) -> Runnable:
         if chat_request.selected_files:
-            return routable_chains.get("chat/documents")
+            return routable_chains.get("summarise")
         else:
             return routable_chains.get("chat")
 

--- a/core-api/core_api/semantic_routes.py
+++ b/core-api/core_api/semantic_routes.py
@@ -49,7 +49,7 @@ def get_routable_chains(
                 "Answer questions as a helpful assistant",
             ),
             (
-                ChatRoute.chat_with_docs,
+                ChatRoute.summarise,
                 chat_with_docs_chain,
                 "Answer questions as a helpful assistant using the documents provided",
             ),

--- a/django_app/redbox_app/templates/macros/chat-macros.html
+++ b/django_app/redbox_app/templates/macros/chat-macros.html
@@ -14,7 +14,7 @@
       <ul class="iai-chat-bubble__route-list">
         <li class="iai-chat-bubble__route-list-item">I can <strong>@chat</strong> about general questions, not related
           to your documents</li>
-        <li class="iai-chat-bubble__route-list-item">I can <strong>@chat/documents</strong> over selected documents and
+        <li class="iai-chat-bubble__route-list-item">I can <strong>@summarise</strong> over selected documents and
           do Q&amp;A on them, extract information, summarise and more!</li>
         <li class="iai-chat-bubble__route-list-item">I can help you <strong>@search</strong> over selected documents and
           do Q&amp;A on them, with citations</li>


### PR DESCRIPTION
## Context
@summarise works, but the tooltip in the chat when this is done reads: Response generated using @chat/documents route

which is immensely confusing and unhelpful, it should read @summarise

similarly, the second bullet point should read @summarise not @chat/documents so really this is just something we should change

## Changes proposed in this pull request
Very simple change showing the summarise route properly and changing the html for the tooltip

## Guidance to review
Check you agree with the approach
