### PR TITLE
fix: api keys redacted in logs

### DIFF
--- a/redbox-core/redbox/api/callbacks.py
+++ b/redbox-core/redbox/api/callbacks.py
@@ -9,9 +9,28 @@ class LoggerCallbackHandler(BaseCallbackHandler):
     def __init__(self, logger: Logger):
         self.logger: Logger = logger
 
+    def redact_secrets(self, data: dict[str, Any]) -> dict[str, Any]:
+        """Redact sensitive information such as API keys."""
+        repr_str = data['repr']
+
+        start_token = "openai_api_key='"
+        end_token = "',"
+
+        start_index = repr_str.find(start_token) + len(start_token)
+        end_index = repr_str.find(end_token, start_index)
+
+        current_openai_api_key = repr_str[start_index:end_index]
+
+        new_repr_str = repr_str.replace(f"openai_api_key='{current_openai_api_key}'", "openai_api_key='<REDACTED>'")
+
+        data['repr'] = new_repr_str
+
+        return data
+
     def on_llm_start(self, serialized: dict[str, Any], prompts: list[str], **kwargs: Any) -> None:  # noqa:ARG002
         """Run when LLM starts running."""
-        self.logger.info("LLM start: %s, prompts: %s", serialized, prompts)
+        redacted_serialized = self.redact_secrets(serialized)
+        self.logger.info("LLM start: %s, prompts: %s", redacted_serialized, prompts)
 
     def on_llm_end(self, response: LLMResult, **kwargs: Any) -> None:  # noqa:ARG002
         """Run when LLM ends running."""


### PR DESCRIPTION
## Context
As a security aware user, I want to remove all logs of api keys so that I do not expose the service to credential leakage. At the moment we are leaking the open api key in the core api service.

## Changes proposed in this pull request
Iterate through serialized output to redact sensitive information before it is sent to server's logs.

## Guidance to review
Check you're happy with the approach taken and think it is robust enough for future possible secret leaks.

