### PR TITLE
Introduce FAQs onto homepage

### DIFF
--- a/django_app/redbox_app/templates/base.html
+++ b/django_app/redbox_app/templates/base.html
@@ -53,6 +53,12 @@
 <body class="govuk-template__body">
   <script hash="sha256-GUQ5ad8JK5KmEWmROf3LZd9ge94daqNvd8xy9YS1iDw=">document.body.className += ' js-enabled' + ('noModule' in HTMLScriptElement.prototype ? ' govuk-frontend-supported' : '');</script>
 
+  <script type="module" src="{{static('js/libs/govuk-frontend.min.js')}}" nonce="{{ request.csp_nonce }}"></script> 
+  <script type="module" nonce="{{ request.csp_nonce }}">
+    import { initAll } from '../static/js/libs/govuk-frontend.min.js'
+    initAll()
+  </script>
+
   <a href="#main-content" class="govuk-skip-link" data-module="govuk-skip-link">Skip to main content</a>
 
   {% if environment | lower != "prod" %}

--- a/django_app/redbox_app/templates/homepage.html
+++ b/django_app/redbox_app/templates/homepage.html
@@ -30,15 +30,155 @@
 
 <div class="govuk-width-container">
     <div class="govuk-grid-row">
-        <div class="govuk-grid-column-two-thirds">
-
+        <div class="govuk-grid-column-one-third-from-desktop govuk-!-margin-bottom-8">
             <h2 class="govuk-heading-m govuk-!-margin-top-5 govuk-!-padding-top-5">Upload</h2>
             <p class="govuk-body ">Easily upload a wide range of document formats into your personal Redbox.</p>
+        </div>
+        <div class="govuk-grid-column-one-third-from-desktop govuk-!-margin-bottom-8">
             <h2 class="govuk-heading-m govuk-!-margin-top-5 govuk-!-padding-top-5">Chat</h2>
             <p class="govuk-body">You can communicate with your Redbox and ask questions of the documents contained within. Use Redbox to unlock deeper insights in the various documents you have uploaded, pulling together summaries of individual or combined documents.</p>
+        </div>
+        <div class="govuk-grid-column-one-third-from-desktop govuk-!-margin-bottom-8">
             <h2 class="govuk-heading-m govuk-!-margin-top-5 govuk-!-padding-top-5">Secure</h2>
             <p class="govuk-body">Redbox is built in our secure and private cloud which enables you to upload, up to, and including, {{ security }} documents in your Redbox.</p>
+        </div>
+    </div>
+</div>
 
+<hr class="govuk-section-break govuk-section-break--visible">
+<div class="govuk-width-container">
+    <div class="govuk-grid-row">
+        <div class="govuk-grid-column-two-thirds">
+            <h1 class="govuk-heading-m govuk-!-margin-top-5 govuk-!-padding-top-5">Frequently Asked Questions</h1>
+            <p class="govuk-body ">Responses to these FAQs about Redbox were generated using Redbox.</p>
+        </div>
+    </div>
+    <div class="govuk-accordion" data-module="govuk-accordion" id="faq">
+        <div class="govuk-accordion__section">
+            <div class="govuk-accordion__section-header">
+                <h2 class="govuk-accordion__section-heading">
+                    <span class="govuk-accordion__section-button" id="faq-question-1">
+                        What is Redbox?
+                    </span>
+                </h2>
+            </div>
+            <div class="govuk-accordion__section-content" id="faq-content-1">
+                <p class="govuk-body">
+                    I am an AI assistant called Redbox, designed to answer questions and provide information based on a wide range of topics, using objective data and insights.
+                </p>
+            </div>
+        </div>
+        <div class="govuk-accordion__section">
+            <div class="govuk-accordion__section-header">
+                <h2 class="govuk-accordion__section-heading">
+                    <span class="govuk-accordion__section-button" id="faq-question-2">
+                        What is Generative AI?
+                    </span>
+                </h2>
+            </div>
+            <div class="govuk-accordion__section-content" id="faq-content-2">
+                <p class="govuk-body">
+                    I am an AI assistant called Redbox, designed to answer questions and provide information based on a wide range of topics, using objective data and insights.
+                </p>
+            </div>
+        </div>
+        <div class="govuk-accordion__section">
+            <div class="govuk-accordion__section-header">
+                <h2 class="govuk-accordion__section-heading">
+                    <span class="govuk-accordion__section-button" id="faq-question-3">
+                        Do I need technical skills to use Redbox?
+                    </span>
+                </h2>
+            </div>
+            <div class="govuk-accordion__section-content" id="faq-content-3">
+                <p class="govuk-body">
+                    I am an AI assistant called Redbox, designed to answer questions and provide information based on a wide range of topics, using objective data and insights.
+                </p>
+            </div>
+        </div>
+        <div class="govuk-accordion__section">
+            <div class="govuk-accordion__section-header">
+                <h2 class="govuk-accordion__section-heading">
+                    <span class="govuk-accordion__section-button" id="faq-question-4">
+                        What can I and can’t I share with Redbox?
+                    </span>
+                </h2>
+            </div>
+            <div class="govuk-accordion__section-content" id="faq-content-4">
+                <p class="govuk-body">
+                    You can share general questions and topics for information or help. However, you should not share personal, sensitive, or confidential information, including financial details, passwords, or private identifiers, as I am designed to prioritize user privacy and security.
+                </p>
+            </div>
+        </div>
+        <div class="govuk-accordion__section">
+            <div class="govuk-accordion__section-header">
+                <h2 class="govuk-accordion__section-heading">
+                    <span class="govuk-accordion__section-button" id="faq-question-5">
+                        What is a ‘hallucination’?
+                    </span>
+                </h2>
+            </div>
+            <div class="govuk-accordion__section-content" id="faq-content-5">
+                <p class="govuk-body">
+                    In the context of AI, a "hallucination" refers to an instance where a generative model produces information or responses that are plausible-sounding but factually incorrect or entirely fabricated. This phenomenon can occur when the model extrapolates from its training data in ways that lead to inaccuracies.
+                </p>
+            </div>
+        </div>
+        <div class="govuk-accordion__section">
+            <div class="govuk-accordion__section-header">
+                <h2 class="govuk-accordion__section-heading">
+                    <span class="govuk-accordion__section-button" id="faq-question-6">
+                        What are the main things Redbox can do? 
+                    </span>
+                </h2>
+            </div>
+            <div class="govuk-accordion__section-content" id="faq-content-6">
+                <p class="govuk-body">
+                    Redbox can answer questions across a wide range of topics, provide explanations and definitions, assist with problem-solving, generate ideas, and offer insights based on available information. Additionally, it can help users better understand complex subjects and guide them in finding resources or information.
+                </p>
+            </div>
+        </div>
+        <div class="govuk-accordion__section">
+            <div class="govuk-accordion__section-header">
+                <h2 class="govuk-accordion__section-heading">
+                    <span class="govuk-accordion__section-button" id="faq-question-7">
+                        What can’t Redbox do? 
+                    </span>
+                </h2>
+            </div>
+            <div class="govuk-accordion__section-content" id="faq-content-7">
+                <p class="govuk-body">
+                    Redbox cannot perform tasks that require personal judgment, such as making decisions for individuals, offering medical or legal advice, providing real-time data updates, or processing personal transactions. It is also unable to access external databases or browse the internet for live information beyond its training data.
+                </p>
+            </div>
+        </div>
+        <div class="govuk-accordion__section">
+            <div class="govuk-accordion__section-header">
+                <h2 class="govuk-accordion__section-heading">
+                    <span class="govuk-accordion__section-button" id="faq-question-8">
+                        Why can Redbox get things wrong? 
+                    </span>
+                </h2>
+            </div>
+            <div class="govuk-accordion__section-content" id="faq-content-8">
+                <p class="govuk-body">
+                    Redbox can get things wrong due to limitations in its training data, potential biases in the information it was trained on, and the inherent complexities of language and context. Additionally, the model may misinterpret questions or generate responses that seem plausible but are incorrect, known as "hallucinations."
+                </p>
+            </div>
+        </div>
+        <div class="govuk-accordion__section">
+            <div class="govuk-accordion__section-header">
+                <h2 class="govuk-accordion__section-heading">
+                    <span class="govuk-accordion__section-button" id="faq-question-9">
+                        How and when does Redbox include sources in its responses?  
+                    </span>
+                </h2>
+            </div>
+            <div class="govuk-accordion__section-content" id="faq-content-9">
+                <p class="govuk-body">
+                    Redbox does not directly include sources in its responses, as it generates information based on a wide range of training data rather than from specific, citable sources. However, it aims to provide accurate and reliable information based on common knowledge up to its last training cut-off in October 2023. If you require sourcing, it's recommended to verify the information from credible sources independently.
+                </p>
+            </div>
         </div>
     </div>
 </div>


### PR DESCRIPTION
## Context

Introducing an FAQ onto the homepage using govuk frontend accordion styling.  Also rearranging the 'Chat', 'Upload' and 'Secure' descriptors to be in columns rather than paragraphs under each other.

## Changes proposed in this pull request

Here is the current UI: 
<img width="1393" alt="Screenshot 2024-09-11 at 14 06 39" src="https://github.com/user-attachments/assets/8b4d0921-c43e-4675-a74f-440e8d80b16e">

Here is the new UI:
<img width="1312" alt="Screenshot 2024-09-11 at 14 07 14" src="https://github.com/user-attachments/assets/f703f54c-1022-46c6-a12e-3770fb7dd39c">



## Guidance to review

<!-- How could someone else check this work? Which parts do you want more feedback on? -->

## Relevant links


## Things to check

- [ ] I have added any new ENV vars in all deployed environments
- [ ] I have tested any code added or changed
- [ ] I have run integration tests
- [ ] I have added/updated any DBT specific changes to .env.uktrade
