### PR TITLE
Updated FAQ homepage and link to advanced FAQs

### DIFF
--- a/django_app/redbox_app/templates/chats.html
+++ b/django_app/redbox_app/templates/chats.html
@@ -19,15 +19,23 @@
     <div class="govuk-grid-column-one-third">
 
       <a class="iai-large-button" role="button" href="{{ url('chats') }}">
-        <svg width="22" height="22" fill="none" aria-hidden="true" focusable="false"><path d="M21 11c0-5.523-4.477-10-10-10S1 5.477 1 11s4.477 10 10 10 10-4.477 10-10z" stroke="currentColor" stroke-linejoin="round"/><g filter="url(#A)"><path d="M15.656 11.656h-4v4h-1.312v-4h-4v-1.312h4v-4h1.312v4h4v1.312z" fill="currentColor"/></g><defs><filter x="6" y="6" width="10" height="10" filterUnits="userSpaceOnUse" color-interpolation-filters="sRGB"><feFlood flood-opacity="0" result="A"/><feColorMatrix in="SourceAlpha" values="0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 127 0"/><feOffset dx="1" dy="1"/><feColorMatrix values="0 0 0 0 1 0 0 0 0 1 0 0 0 0 1 0 0 0 1 0"/><feBlend in2="A"/><feBlend in="SourceGraphic"/></filter></defs></svg>
+        <svg width="22" height="22" fill="none" aria-hidden="true" focusable="false">
+          <path d="M21 11c0-5.523-4.477-10-10-10S1 5.477 1 11s4.477 10 10 10 10-4.477 10-10z" stroke="currentColor" stroke-linejoin="round"/>
+          <g filter="url(#A)">
+            <path d="M15.656 11.656h-4v4h-1.312v-4h-4v-1.312h4v-4h1.312v4h4v1.312z" fill="currentColor"/>
+          </g>
+          <defs>
+            <filter x="6" y="6" width="10" height="10" filterUnits="userSpaceOnUse" color-interpolation-filters="sRGB">
+              <feFlood flood-opacity="0" result="A"/>
+              <feColorMatrix in="SourceAlpha" values="0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 127 0"/>
+              <feOffset dx="1" dy="1"/><feColorMatrix values="0 0 0 0 1 0 0 0 0 1 0 0 0 0 1 0 0 0 1 0"/>
+              <feBlend in2="A"/>
+              <feBlend in="SourceGraphic"/>
+            </filter>
+          </defs>
+        </svg>
         New chat
       </a>
-
-      <div class="rb-banner__links">
-        <a href="/faq/" role="button" class="govuk-button--secondary govuk-!-margin-bottom-0 rb-banner__button" target="_blank" data-module="govuk-button">
-          Advanced Prompt FAQ
-        </a>
-      </div>
 
       <div class="iai-panel govuk-!-margin-top-6">
         <h2 class="govuk-heading-s">Recent chats</h2>
@@ -132,6 +140,9 @@
             </button>
           </div>
         </div>
+        <p class="govuk-body">
+          Need help? Read through our <a href="{{ url('faq') }}" class="govuk-link" target="_blank">Advanced Prompt FAQ</a> section.
+        </p>
         <p class="iai-chat-input__info-text">Redbox can make mistakes. You must check for accuracy before using the output.</p>
         <p class="iai-chat-input__info-text">You can use up to, and including, official sensitive documents.</p>
       </div>

--- a/django_app/redbox_app/templates/homepage.html
+++ b/django_app/redbox_app/templates/homepage.html
@@ -64,7 +64,11 @@
             </div>
             <div class="govuk-accordion__section-content" id="faq-content-1">
                 <p class="govuk-body">
-                    I am an AI assistant called Redbox, designed to answer questions and provide information based on a wide range of topics, using objective data and insights.
+                    Redbox is a new kind of tool for civil servants which uses Large Language Models (LLMs) to process text-based information.
+                    Redbox is currently only available to a small number of DBT staff as the department assesses its usefulness.
+                </p>
+                <p class="govuk-body">
+                    What makes Redbox particularly useful is that it can look at any documents you upload and work with you on them.
                 </p>
             </div>
         </div>
@@ -78,7 +82,9 @@
             </div>
             <div class="govuk-accordion__section-content" id="faq-content-2">
                 <p class="govuk-body">
-                    I am an AI assistant called Redbox, designed to answer questions and provide information based on a wide range of topics, using objective data and insights.
+                    Generative AI is a fairly new kind of algorithmic machine learning based on 'neural architecture'  This architecture allows
+                    machine learning models (called large language models in this case) to be trained on large amounts of information, and then
+                    be able to converse with a user by 'generating' answers to questions or assisting with text-based processing tasks.
                 </p>
             </div>
         </div>
@@ -92,7 +98,11 @@
             </div>
             <div class="govuk-accordion__section-content" id="faq-content-3">
                 <p class="govuk-body">
-                    I am an AI assistant called Redbox, designed to answer questions and provide information based on a wide range of topics, using objective data and insights.
+                    Not at all, the interface for Redbox comprises a document upload feature and a chat feature.  No technical skills are required,
+                    but an understanding of what large language models are and what they can do makes an enormous different to users when interacting
+                    with them.  The principal skill to use Redbox well comes down to a skill called 'prompt engineering', which is just natural language
+                    you type in and get the tool to respond.  There are some great Gov.uk short courses on generative AI you may consider taking: 
+                    <a href="https://cddo.blog.gov.uk/2024/01/19/artificial-intelligence-introducing-our-series-of-online-courses-on-generative-ai/" class="govuk-link">See the courses here</a>.
                 </p>
             </div>
         </div>
@@ -106,7 +116,14 @@
             </div>
             <div class="govuk-accordion__section-content" id="faq-content-4">
                 <p class="govuk-body">
-                    You can share general questions and topics for information or help. However, you should not share personal, sensitive, or confidential information, including financial details, passwords, or private identifiers, as I am designed to prioritize user privacy and security.
+                    For the moment, you can share text and documents up to the {{ security }} classification level.  Take care to check before sharing
+                    text or documents with Redbox that they do not exceed this designation.
+                </p>
+                <p class="govuk-body">
+                    Alongside this, do not share Personal Data with Redbox, for more information on what constitutes personal data, watch this short
+                    <a href="https://dbis.sharepoint.com/sites/DataProtectionOSS/SitePages/Your-guide-to-understanding-personal-data.aspx" class="govuk-link">video</a>.  If
+                    you are unsure whether you are processing personal data, you should contact the <a href="https://workspace.trade.gov.uk/teams/data-protection-and-gdpr/" class="govuk-link">Data Protection Team</a>
+                     to check.
                 </p>
             </div>
         </div>
@@ -120,7 +137,9 @@
             </div>
             <div class="govuk-accordion__section-content" id="faq-content-5">
                 <p class="govuk-body">
-                    In the context of AI, a "hallucination" refers to an instance where a generative model produces information or responses that are plausible-sounding but factually incorrect or entirely fabricated. This phenomenon can occur when the model extrapolates from its training data in ways that lead to inaccuracies.
+                    In the context of LLMs, a hallucination refers to the generation of information that is incorrect, nonsensical, or entirely fabricated, despite
+                    being presented in a credible manner.  This can happen when the model produces details, facts, or asserts that are not grounded in reality or the
+                    data it was trained on, potentialliy leading to misinformation or misunderstanding.
                 </p>
             </div>
         </div>
@@ -134,8 +153,44 @@
             </div>
             <div class="govuk-accordion__section-content" id="faq-content-6">
                 <p class="govuk-body">
-                    Redbox can answer questions across a wide range of topics, provide explanations and definitions, assist with problem-solving, generate ideas, and offer insights based on available information. Additionally, it can help users better understand complex subjects and guide them in finding resources or information.
+                    Redbox allows you to chat to a LLM, summarise and interact with documents (up to around 140 pages), and even search within documents.  Here are some 
+                    helpful insights into those:
                 </p>
+                <h4 class="govuk-heading-m govuk-!-margin-top-1">Chat</h4>
+                <p class="govuk-body">
+                    By using <b>@chat</b> at the beginning of any message you send, you will speak directly with the LLM, gaining access to its 'world model', which is everything
+                    it was trained on.
+                </p>
+                <div class="govuk-inset-text">
+                    <p class="govuk-body">
+                        <b>Top tip:</b> when you chat with the LLM, all the contents of your current chat are considered by the LLM, and you can switch between chat and other interaction
+                        types (more below) in the same chat.
+                    </p>
+                </div>
+                <h4 class="govuk-heading-m govuk-!-margin-top-1">Summarise</h4>
+                <p class="govuk-body">
+                    By using <b>@summarise</b> at the beginning of any message you send, and ensuring that a document is selected in the left hand panel, you can get the LLM to
+                    look at an entire document and summarise it for you.
+                </p>
+                <div class="govuk-inset-text">
+                    <p class="govuk-body">
+                        <b>Top tip:</b> like using @chat, using the @summarise feature is very flexible, and you can instruct the LLM to summarise from a particular point of view, or
+                    follow a particular kind of format in its response.  Here's an example prompt - imagine you have selected an HR Policy document on taking leave at DBT: <br><br>
+                    <i>@summarise this HR policy from the perspective of a line manager, as my line report has asked to take extended leave and I want to know what steps I need to take.</i><br><br>
+                    In this example, Redbox will take those instructions into account and generate a response that best fits your requirements.
+                    </p>
+                </div>
+                <h4 class="govuk-heading-m govuk-!-margin-top-1">Search</h4>
+                <p class="govuk-body">
+                    By using <b>@search</b> at the beginning of any message you send, with any number of documents selected in the side panel, Redbox will search within them
+                    for results that relate to the question or instruction given.
+                </p>
+                <div class="govuk-inset-text">
+                    <p class="govuk-body">
+                        <b>Top tip:</b> Search is great at finding exact parts of documents which relate to a given theme or topic, and the results will also show you the exact
+                        text it found from the documents os you can be sure of accuracy.
+                    </p>
+                </div>
             </div>
         </div>
         <div class="govuk-accordion__section">
@@ -148,7 +203,16 @@
             </div>
             <div class="govuk-accordion__section-content" id="faq-content-7">
                 <p class="govuk-body">
-                    Redbox cannot perform tasks that require personal judgment, such as making decisions for individuals, offering medical or legal advice, providing real-time data updates, or processing personal transactions. It is also unable to access external databases or browse the internet for live information beyond its training data.
+                    Redbox is limited to its own training data and document processing, as it cannot currently search the internet, making it inadequate for getting reliable real-time information.
+                </p>
+                <p class="govuk-body">
+                    Redbox is not well-suited for tasks that involve precise numerical calculations, counting, or data tabulation, such as those often required in spreadsheets or financial analyses.  They
+                    may generate incorrect numerical results or misinterpret mathematical expressions, leading to unrealiable outputs.  Additionally, Redbox struggles with organising and
+                    manipulating structured data effectively, as it is primarily designed for language generation rather than data processing.
+                </p>
+                <p class="govuk-body">
+                    This can make Redbox inadequate for tasks requiring accurate data comparison, aggregation, and spreadsheet functions, where human oversight and intervention remain essential
+                    for ensuring accuracy and reliability.
                 </p>
             </div>
         </div>
@@ -162,21 +226,10 @@
             </div>
             <div class="govuk-accordion__section-content" id="faq-content-8">
                 <p class="govuk-body">
-                    Redbox can get things wrong due to limitations in its training data, potential biases in the information it was trained on, and the inherent complexities of language and context. Additionally, the model may misinterpret questions or generate responses that seem plausible but are incorrect, known as "hallucinations."
-                </p>
-            </div>
-        </div>
-        <div class="govuk-accordion__section">
-            <div class="govuk-accordion__section-header">
-                <h2 class="govuk-accordion__section-heading">
-                    <span class="govuk-accordion__section-button" id="faq-question-9">
-                        How and when does Redbox include sources in its responses?  
-                    </span>
-                </h2>
-            </div>
-            <div class="govuk-accordion__section-content" id="faq-content-9">
-                <p class="govuk-body">
-                    Redbox does not directly include sources in its responses, as it generates information based on a wide range of training data rather than from specific, citable sources. However, it aims to provide accurate and reliable information based on common knowledge up to its last training cut-off in October 2023. If you require sourcing, it's recommended to verify the information from credible sources independently.
+                    Redbox can get things wrong for several reasons, primarily due to its reliance on patterns found in the training data of the LLM rather than true understanding or 
+                    reasoning.  Redbox may generate inaccurate information because they lack context awareness, leading to misinterpretations, especially in complex or nuanced scenarios.
+                    Additionally, biases inherent in the LLM training data can result in the propagation of errors, stereotypes, or nonsensical outputs, further compromising the accuracy of Redbox' responses.
+                    For more information, read the FAQ section on 'hallucinations' above.
                 </p>
             </div>
         </div>


### PR DESCRIPTION
## Context

Updates to the content of the FAQ page have been made, as well as the link placement for getting to the Advanced Prompt FAQs section on the /chats/ page.

## Changes proposed in this pull request

Example of content on FAQ page: 

<img width="987" alt="image" src="https://github.com/user-attachments/assets/0dcbc2ef-8f67-4478-9b85-cefc4e8e8974">

Final position of Advanced Prompt FAQ link:

<img width="653" alt="image" src="https://github.com/user-attachments/assets/3ab2c386-c144-4a85-9259-ecf5d2391be1">

## Things to check

- [ ] I have added any new ENV vars in all deployed environments
- [ ] I have tested any code added or changed
- [ ] I have run integration tests
- [ ] I have added/updated any DBT specific changes to .env.uktrade
